### PR TITLE
Miscellany

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You must have GDAL installed.
 
     $ npm start
 
-The defaul setting runs 20 tasks in parallel. You can change the number by playing around with `var limitParallel = 20;` on line 13 of `index.js`
+The default setting runs 20 tasks in parallel. You can change the number by playing around with `var limitParallel = 20;` on line 13 of `index.js`
 
 ### Expected Output
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/scisco/oam-meta-generator.git"
+    "url": "https://github.com/openimagerynetwork/oam-meta-generator.git"
   },
   "keywords": [
     "OpenAerialMap",
@@ -20,9 +20,9 @@
   "author": "Development Seed",
   "license": "CC01",
   "bugs": {
-    "url": "https://github.com/scisco/oam-meta-generator/issues"
+    "url": "https://github.com/openimagerynetwork/oam-meta-generator/issues"
   },
-  "homepage": "https://github.com/scisco/oam-meta-generator",
+  "homepage": "https://github.com/openimagerynetwork/oam-meta-generator",
   "dependencies": {
     "envloader": "0.0.2",
     "fs-extra": "^0.18.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "oam-meta-generator",
+  "name": "oin-meta-generator",
   "version": "0.1.0",
-  "description": "A metadata generator for OAM imagery",
+  "description": "A metadata generator for OIN imagery",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/semistandard/bin/cmd.js",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "envloader": "0.0.2",
     "fs-extra": "^0.18.3",
-    "gdalinfo-json": "^0.4.0",
+    "gdalinfo-json": "github:mojodna/gdalinfo-json#upgrade-gdal",
     "lodash": "^3.8.0",
     "s3": "^4.4.0"
   },


### PR DESCRIPTION
Typo, some GitHub link updates, and an update of `gdalinfo-json` to allow pre-built binaries to work with Node-4.x and later.

See also: https://github.com/scisco/gdalinfo-json/pull/4