### PR TITLE
Revert bbox/footprint to EPSG:4326

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+'use strict';
+
 const fs = require('fs');
 
 require('epipebomb')();

--- a/lib/GdalInfo.js
+++ b/lib/GdalInfo.js
@@ -30,24 +30,39 @@ class GdalInfo {
     return this.src.srs.toWKT();
   }
 
+  envelope () {
+    let envelope = new gdal.Envelope({
+      minX: this.westernExtreme,
+      minY: this.southernExtreme,
+      maxX: this.easternExtreme,
+      maxY: this.northernExtreme
+    });
+
+    // TODO: Converting to a CRS different from that specified in `projection` may
+    // not be appropriate to the specfication.
+    // Follow: https://github.com/openimagerynetwork/oin-meta-generator/issues/26
+    if (this.isImageryMetric()) {
+      const epsg4326 = gdal.SpatialReference.fromEPSG(4326);
+      const metricToEPSG = new gdal.CoordinateTransformation(this.src.srs, epsg4326);
+      envelope = envelope.toPolygon();
+      envelope.transform(metricToEPSG);
+      envelope = envelope.getEnvelope();
+    }
+
+    return envelope;
+  }
+
   bboxAsWKT () {
-    const ul = new gdal.Point(this.westernExtreme, this.northernExtreme);
-    const ur = new gdal.Point(this.easternExtreme, this.northernExtreme);
-    const lr = new gdal.Point(this.easternExtreme, this.southernExtreme);
-    const ll = new gdal.Point(this.westernExtreme, this.southernExtreme);
-    let extent = new gdal.Polygon();
-    let ring = new gdal.LinearRing();
-    ring.points.add([ul, ur, lr, ll, ul]);
-    extent.rings.add(ring);
-    return extent.toWKT();
+    return this.envelope().toPolygon().toWKT();
   }
 
   bboxAsArray () {
+    const envelope = this.envelope();
     return [
-      this.westernExtreme,
-      this.southernExtreme,
-      this.easternExtreme,
-      this.northernExtreme
+      envelope.minX,
+      envelope.minY,
+      envelope.maxX,
+      envelope.maxY
     ];
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -14,14 +14,24 @@ describe('Getting GDAL info', function () {
   describe('The Bounding Box', function () {
     it('should output the 4 corners', function () {
       expect(metricImagery.bboxAsArray()).to.deep.eq(
-        [481235, 3084435, 504335, 3107535]
+        [
+          86.80898421199673,
+          27.88461236744702,
+          87.04412764300424,
+          28.093267989875276
+        ]
       );
     });
 
     it('should output the 4 corners as a WKT POLYGON()', function () {
       expect(metricImagery.bboxAsWKT()).to.eq(
-        'POLYGON ((481235 3107535,504335 3107535,' +
-        '504335 3084435,481235 3084435,481235 3107535))'
+        'POLYGON ((' +
+          '86.8089842119967 27.884612367447,' +
+          '87.0441276430042 27.884612367447,' +
+          '87.0441276430042 28.0932679898753,' +
+          '86.8089842119967 28.0932679898753,' +
+          '86.8089842119967 27.884612367447' +
+        '))'
       );
     });
   });
@@ -93,7 +103,12 @@ describe('CLI usage', function () {
       expect(result.acquisition_end).to.eq('2015-04-30T00:00:00.000Z');
       expect(result.properties.sensor).to.eq('Some Algorithm');
       expect(result.projection).to.contain('WGS 84 / UTM zone 45N');
-      expect(result.bbox).to.deep.eq([481235, 3084435, 504335, 3107535]);
+      expect(result.bbox).to.deep.eq([
+        86.80898421199673,
+        27.88461236744702,
+        87.04412764300424,
+        28.093267989875276
+      ]);
       done();
     });
   });


### PR DESCRIPTION
This is likely to be a temporary hotfix to support consumers
of OIN meta data that have assumed `bbox` and `footprint` to be
in standard EPSG:4326 coordinates. Ultimately, the hope is that
all coords in the metadata will be in the same CRS as that specified
by `projection`.

Closes #25